### PR TITLE
Fix for dark style not being applied

### DIFF
--- a/src/Hangfire.Dashboard.Dark/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.Dashboard.Dark/GlobalConfigurationExtensions.cs
@@ -20,7 +20,7 @@ namespace Hangfire.Dashboard.Dark
 
             // register dispatchers for CSS
             var assembly = typeof(GlobalConfigurationExtensions).GetTypeInfo().Assembly;            
-            DashboardRoutes.Routes.Append("/css[0-9]+", new EmbeddedResourceDispatcher(assembly, "Hangfire.Dashboard.Dark.Resources.slate.min.css"));
+            DashboardRoutes.Routes.Append("/css[0-9]+", new EmbeddedResourceDispatcher(assembly, "Hangfire.Dashboard.Dark.Resources.style.min.css"));
             
             return configuration;
         }

--- a/src/Hangfire.Dashboard.Dark/GlobalConfigurationExtensions.cs
+++ b/src/Hangfire.Dashboard.Dark/GlobalConfigurationExtensions.cs
@@ -19,9 +19,9 @@ namespace Hangfire.Dashboard.Dark
                 throw new ArgumentNullException(nameof(configuration));
 
             // register dispatchers for CSS
-            var assembly = typeof(GlobalConfigurationExtensions).GetTypeInfo().Assembly;
-            DashboardRoutes.Routes.Append("/css[0-9]{3}", new EmbeddedResourceDispatcher(assembly, "Hangfire.Dashboard.Dark.Resources.style.min.css"));
-
+            var assembly = typeof(GlobalConfigurationExtensions).GetTypeInfo().Assembly;            
+            DashboardRoutes.Routes.Append("/css[0-9]+", new EmbeddedResourceDispatcher(assembly, "Hangfire.Dashboard.Dark.Resources.slate.min.css"));
+            
             return configuration;
         }
     }


### PR DESCRIPTION
In GlobalConfigurationExtension.cs, in the UseDarkDashboard extension method, the css path was not matching when passed to the DashboardRoutes.Routes.Append method. Changing the path to the same that was already in the route list fixed the problem (use "/css[0-9]+" instead of "/css[0-9]{3}").